### PR TITLE
Release 1.29.4

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -51,8 +51,8 @@ jobs:
           # config_file: configs/changelog-ci-config.json
           # Optional, This will be used to configure git
           # defaults to `github-actions[bot]` if not provided.
-          committer_username: 'Majid Rehman'
-          committer_email: 'majid.rehman@vultara.com'
+          #committer_username: 'Majid Rehman'
+          #committer_email: 'majid.rehman@vultara.com'
           # Optional, only required when you want to run Changelog CI 
           # on an event other than `pull_request` event.
           # In this example `release_version` is fetched from `workflow_dispatch` events input.

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           tag_name: ${{ env.RELEASE_VERSION }}
-          name: ${{ env.RELEASE_VERSION }}
+          name: v${{ env.RELEASE_VERSION }}
           body: ${{steps.github_release.outputs.changelog}}
           draft: false
           prerelease: false

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -1,4 +1,4 @@
-name: 'CI'
+name: 'Release CI'
 on:
   push:
     tags:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-example-kitchensink",
-  "version": "11.0.3",
+  "version": "1.29.4",
   "description": "This is an example app used to showcase Cypress.io testing. For a full reference of our documentation, go to https://docs.cypress.io",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Hi @majid-vultara!
This PR was created in response to a manual trigger of the release workflow here: https://github.com/majid-vultara/cypress-test/actions/runs/1929782148.
I've updated the changelog and bumped the versions in the manifest files in this commit: ed66456517e837ac17b9db2c9394e39630f5a44d.
Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.